### PR TITLE
Nice to have: New import type rainSTORM v3.x

### DIFF
--- a/fileIO/Ascii/rainSTORM_v3_x.m
+++ b/fileIO/Ascii/rainSTORM_v3_x.m
@@ -1,0 +1,21 @@
+%;//File specification for rainSTORM v3.x
+fs.fileType = 'csv';
+fs.nHeaderLines = 1 ;
+fs.delimiter = ',';
+fs.headerPrefix = ''; 
+fs.headerPostfix= ''; 
+fs.colNames={'idx',
+   'frame_idx',
+   'x_coord',
+   'y_coord',
+   'x_std',
+   'y_std',
+   'I',
+   'sig_x',
+   'sig_y'};
+fs.numberFormat='%g';
+%[OptionalColumnAssignments]
+fs.xCol='x_coord';
+fs.yCol='y_coord';
+fs.frameCol='frame_idx';
+fs.idCol='idx';


### PR DESCRIPTION
A new file specification for rainSTORM v3.x exported *_reviewedSupResParams.csv* data.
To export the super-resolved data in the Reviewer (rainSTORM_Image_Viewer), the user should select **Save Loc. Data**.
Further references and where to get rainSTORM:
  - [Advanced Optical Imaging Group](http://titan.physx.u-szeged.hu/~adoptim/)
  - [Laser Analytics Group - Resources](http://laser.ceb.cam.ac.uk/research/resources)